### PR TITLE
feat(offline): offline mode with response caching and request queuing (issue #12)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,9 @@ import 'providers/accessibility_provider.dart';
 import 'providers/language_provider.dart';
 import 'providers/template_provider.dart';
 import 'screens/home_screen.dart';
+import 'services/connectivity_service.dart';
+import 'services/ussd_cache_service.dart';
+import 'services/offline_queue_service.dart';
 import 'utils/accessibility_themes.dart';
 import 'utils/design_system.dart';
 import 'l10n/generated/app_localizations.dart';
@@ -21,7 +24,25 @@ class UssdEmulatorApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MultiProvider(
       providers: [
-        ChangeNotifierProvider(create: (context) => UssdProvider()),
+        ChangeNotifierProvider(create: (context) => ConnectivityService()),
+        ChangeNotifierProvider(create: (context) => UssdCacheService()),
+        ChangeNotifierProvider(create: (context) => OfflineQueueService()),
+        ChangeNotifierProxyProvider3<ConnectivityService, UssdCacheService,
+            OfflineQueueService, UssdProvider>(
+          create: (context) => UssdProvider(
+            connectivityService: context.read<ConnectivityService>(),
+            cacheService: context.read<UssdCacheService>(),
+            queueService: context.read<OfflineQueueService>(),
+          ),
+          update: (context, connectivity, cache, queue, previous) =>
+              previous ??
+              UssdProvider(
+                connectivityService: connectivity,
+                cacheService: cache,
+                queueService: queue,
+              ),
+        ),
+
         ChangeNotifierProvider(create: (context) => AccessibilityProvider()),
         ChangeNotifierProvider(create: (context) => LanguageProvider()),
         ChangeNotifierProvider(create: (context) => TemplateProvider()),

--- a/lib/providers/ussd_provider.dart
+++ b/lib/providers/ussd_provider.dart
@@ -1,10 +1,14 @@
 import 'package:flutter/foundation.dart';
 import '../models/ussd_session.dart';
 import '../models/ussd_request.dart';
+import '../models/ussd_response.dart';
 import '../models/endpoint_config.dart';
 import '../services/ussd_session_service.dart';
 import '../services/ussd_api_service.dart';
 import '../services/endpoint_config_service.dart';
+import '../services/connectivity_service.dart';
+import '../services/ussd_cache_service.dart';
+import '../services/offline_queue_service.dart';
 import '../utils/ussd_utils.dart';
 
 class UssdProvider with ChangeNotifier {
@@ -12,26 +16,52 @@ class UssdProvider with ChangeNotifier {
   final UssdApiService _apiService = UssdApiService();
   final EndpointConfigService _configService = EndpointConfigService();
 
+  final ConnectivityService _connectivityService;
+  final UssdCacheService _cacheService;
+  final OfflineQueueService _queueService;
+
+  UssdProvider({
+    ConnectivityService? connectivityService,
+    UssdCacheService? cacheService,
+    OfflineQueueService? queueService,
+  })  : _connectivityService = connectivityService ?? ConnectivityService(),
+        _cacheService = cacheService ?? UssdCacheService(),
+        _queueService = queueService ?? OfflineQueueService() {
+    _connectivityService.addListener(_onConnectivityChanged);
+  }
+
   bool _isInitialized = false;
   bool _isLoading = false;
   String? _error;
+  bool _lastResponseFromCache = false;
 
   bool get isInitialized => _isInitialized;
   bool get isLoading => _isLoading;
   String? get error => _error;
+  bool get isOffline => _connectivityService.isOffline;
+  bool get lastResponseFromCache => _lastResponseFromCache;
+  int get queuedRequestCount => _queueService.length;
 
   UssdSession? get currentSession => _sessionService.currentSession;
   List<UssdSession> get sessionHistory => _sessionService.sessionHistory;
   List<EndpointConfig> get endpointConfigs => _configService.configs;
   EndpointConfig? get activeEndpointConfig => _configService.activeConfig;
 
+  UssdCacheService get cacheService => _cacheService;
+  OfflineQueueService get queueService => _queueService;
+
   Future<void> init() async {
     if (_isInitialized) return;
 
     _setLoading(true);
     try {
-      await _sessionService.init();
-      await _configService.init();
+      await Future.wait([
+        _sessionService.init(),
+        _configService.init(),
+        _connectivityService.init(),
+        _cacheService.init(),
+        _queueService.init(),
+      ]);
       _isInitialized = true;
       _clearError();
     } catch (e) {
@@ -82,20 +112,18 @@ class UssdProvider with ChangeNotifier {
 
     _setLoading(true);
     _clearError();
+    _lastResponseFromCache = false;
 
     try {
-      // Check if this is the very first request (no previous requests)
       final isInitialRequest = currentSession!.requests.isEmpty;
 
-      // Add user input to path (except for initial request)
       if (!isInitialRequest) {
         await _sessionService.addUserInputToPath(cleanInput);
         notifyListeners();
       }
 
-      // Build the text field using the updated path
       final textForRequest = isInitialRequest
-          ? '' // Empty text for initial USSD request
+          ? ''
           : UssdUtils.buildTextInput(currentSession!.ussdPath);
 
       final request = UssdRequest(
@@ -108,10 +136,7 @@ class UssdProvider with ChangeNotifier {
       await _sessionService.addRequest(request);
       notifyListeners();
 
-      final response = await _apiService.sendUssdRequest(
-        request,
-        activeEndpointConfig!,
-      );
+      final response = await _sendWithOfflineFallback(request);
 
       await _sessionService.addResponse(response);
       notifyListeners();
@@ -120,6 +145,57 @@ class UssdProvider with ChangeNotifier {
     } finally {
       _setLoading(false);
     }
+  }
+
+  /// Attempts a live request; falls back to cache or queues for later.
+  Future<UssdResponse> _sendWithOfflineFallback(UssdRequest request) async {
+    final config = activeEndpointConfig!;
+
+    if (_connectivityService.isOffline) {
+      final cached = await _cacheService.getCachedResponse(request);
+      if (cached != null) {
+        _lastResponseFromCache = true;
+        return cached;
+      }
+      await _queueService.enqueue(request, config);
+      return const UssdResponse(
+        text: 'You are offline. This request has been queued and will be '
+            'sent automatically when connectivity is restored.',
+        continueSession: false,
+      );
+    }
+
+    try {
+      final response = await _apiService.sendUssdRequest(request, config);
+      await _cacheService.cacheResponse(request, response);
+      return response;
+    } catch (e) {
+      final cached = await _cacheService.getCachedResponse(request);
+      if (cached != null) {
+        _lastResponseFromCache = true;
+        return cached;
+      }
+      await _queueService.enqueue(request, config);
+      rethrow;
+    }
+  }
+
+  void _onConnectivityChanged() {
+    if (_connectivityService.isOnline && !_queueService.isEmpty) {
+      _processQueue();
+    }
+    notifyListeners();
+  }
+
+  Future<void> _processQueue() async {
+    await _queueService.processQueue((queued) async {
+      final response = await _apiService.sendUssdRequest(
+        queued.request,
+        queued.config,
+      );
+      await _cacheService.cacheResponse(queued.request, response);
+    });
+    notifyListeners();
   }
 
   Future<void> endSession() async {
@@ -156,6 +232,7 @@ class UssdProvider with ChangeNotifier {
       notifyListeners();
     } catch (e) {
       _setError('Failed to add endpoint config: ${e.toString()}');
+      rethrow;
     }
   }
 
@@ -165,6 +242,7 @@ class UssdProvider with ChangeNotifier {
       notifyListeners();
     } catch (e) {
       _setError('Failed to update endpoint config: ${e.toString()}');
+      rethrow;
     }
   }
 
@@ -191,8 +269,7 @@ class UssdProvider with ChangeNotifier {
     _clearError();
 
     try {
-      final result = await _apiService.testEndpoint(config);
-      return result;
+      return await _apiService.testEndpoint(config);
     } catch (e) {
       _setError('Failed to test endpoint: ${e.toString()}');
       return false;
@@ -216,7 +293,11 @@ class UssdProvider with ChangeNotifier {
     notifyListeners();
   }
 
-  void clearError() {
-    _clearError();
+  void clearError() => _clearError();
+
+  @override
+  void dispose() {
+    _connectivityService.removeListener(_onConnectivityChanged);
+    super.dispose();
   }
 }

--- a/lib/screens/cache_management_screen.dart
+++ b/lib/screens/cache_management_screen.dart
@@ -1,0 +1,434 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:flutter_animate/flutter_animate.dart';
+import '../providers/ussd_provider.dart';
+import '../services/ussd_cache_service.dart';
+import '../services/offline_queue_service.dart';
+import '../utils/design_system.dart';
+
+class CacheManagementScreen extends StatelessWidget {
+  const CacheManagementScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Offline & Cache'),
+        backgroundColor: Theme.of(context).colorScheme.surfaceContainer,
+        elevation: 0,
+      ),
+      body: Consumer<UssdProvider>(
+        builder: (context, provider, _) {
+          final cache = provider.cacheService;
+          final queue = provider.queueService;
+
+          return ListView(
+            padding: const EdgeInsets.all(UssdDesignSystem.spacingM),
+            children: [
+              _StatsCard(cache: cache, queue: queue)
+                  .animate()
+                  .fadeIn(duration: UssdDesignSystem.animationMedium)
+                  .slideY(begin: 0.2, end: 0.0),
+              const SizedBox(height: UssdDesignSystem.spacingM),
+              _QueueSection(queue: queue, provider: provider)
+                  .animate(delay: const Duration(milliseconds: 100))
+                  .fadeIn(duration: UssdDesignSystem.animationMedium)
+                  .slideY(begin: 0.2, end: 0.0),
+              const SizedBox(height: UssdDesignSystem.spacingM),
+              _CacheSection(cache: cache)
+                  .animate(delay: const Duration(milliseconds: 200))
+                  .fadeIn(duration: UssdDesignSystem.animationMedium)
+                  .slideY(begin: 0.2, end: 0.0),
+              const SizedBox(height: UssdDesignSystem.spacingM),
+              _ActionsSection(cache: cache, queue: queue)
+                  .animate(delay: const Duration(milliseconds: 300))
+                  .fadeIn(duration: UssdDesignSystem.animationMedium)
+                  .slideY(begin: 0.2, end: 0.0),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _StatsCard extends StatelessWidget {
+  final UssdCacheService cache;
+  final OfflineQueueService queue;
+
+  const _StatsCard({required this.cache, required this.queue});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Card(
+      elevation: 1,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(UssdDesignSystem.radiusL),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(UssdDesignSystem.spacingL),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Statistics',
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: UssdDesignSystem.spacingM),
+            Row(
+              children: [
+                Expanded(
+                  child: _StatTile(
+                    icon: Icons.storage_rounded,
+                    label: 'Cached',
+                    value: '${cache.entryCount}',
+                    color: colorScheme.primary,
+                  ),
+                ),
+                Expanded(
+                  child: _StatTile(
+                    icon: Icons.offline_bolt_rounded,
+                    label: 'Hit rate',
+                    value: '${cache.hitRate.toStringAsFixed(0)}%',
+                    color: colorScheme.secondary,
+                  ),
+                ),
+                Expanded(
+                  child: _StatTile(
+                    icon: Icons.queue_rounded,
+                    label: 'Queued',
+                    value: '${queue.length}',
+                    color: queue.isEmpty
+                        ? colorScheme.onSurfaceVariant
+                        : colorScheme.error,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StatTile extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final String value;
+  final Color color;
+
+  const _StatTile({
+    required this.icon,
+    required this.label,
+    required this.value,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Icon(icon, color: color, size: 28),
+        const SizedBox(height: UssdDesignSystem.spacingXS),
+        Text(
+          value,
+          style: Theme.of(context).textTheme.titleLarge?.copyWith(
+            color: color,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        Text(
+          label,
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _QueueSection extends StatelessWidget {
+  final OfflineQueueService queue;
+  final UssdProvider provider;
+
+  const _QueueSection({required this.queue, required this.provider});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Card(
+      elevation: 1,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(UssdDesignSystem.radiusL),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(UssdDesignSystem.spacingL),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.queue_rounded, color: colorScheme.primary, size: 20),
+                const SizedBox(width: UssdDesignSystem.spacingS),
+                Text(
+                  'Offline Queue',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: UssdDesignSystem.spacingM),
+            if (queue.isEmpty)
+              Text(
+                'No requests queued.',
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              )
+            else
+              ...queue.items.map(
+                (item) => ListTile(
+                  contentPadding: EdgeInsets.zero,
+                  leading: Icon(
+                    Icons.pending_rounded,
+                    color: colorScheme.error,
+                    size: 20,
+                  ),
+                  title: Text(
+                    item.request.serviceCode,
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                  subtitle: Text(
+                    '${item.request.phoneNumber} · retries: ${item.retryCount}',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                  trailing: IconButton(
+                    icon: const Icon(Icons.close_rounded, size: 18),
+                    onPressed: () => queue.remove(item.id),
+                    tooltip: 'Remove from queue',
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _CacheSection extends StatelessWidget {
+  final UssdCacheService cache;
+
+  const _CacheSection({required this.cache});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final entries = cache.entries;
+
+    return Card(
+      elevation: 1,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(UssdDesignSystem.radiusL),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(UssdDesignSystem.spacingL),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  Icons.storage_rounded,
+                  color: colorScheme.primary,
+                  size: 20,
+                ),
+                const SizedBox(width: UssdDesignSystem.spacingS),
+                Text(
+                  'Cached Responses',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: UssdDesignSystem.spacingM),
+            if (entries.isEmpty)
+              Text(
+                'No cached responses.',
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              )
+            else
+              ...entries.map(
+                (entry) => ListTile(
+                  contentPadding: EdgeInsets.zero,
+                  leading: Icon(
+                    Icons.offline_bolt_rounded,
+                    color: colorScheme.secondary,
+                    size: 20,
+                  ),
+                  title: Text(
+                    entry.key.split(':').first,
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      fontWeight: FontWeight.w500,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  subtitle: Text(
+                    'hits: ${entry.value.hitCount} · '
+                    'expires: ${_formatExpiry(entry.value)}',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _formatExpiry(CacheEntry entry) {
+    final remaining = entry.ttl - DateTime.now().difference(entry.timestamp);
+    if (remaining.inHours > 0) return '${remaining.inHours}h';
+    if (remaining.inMinutes > 0) return '${remaining.inMinutes}m';
+    return 'soon';
+  }
+}
+
+class _ActionsSection extends StatelessWidget {
+  final UssdCacheService cache;
+  final OfflineQueueService queue;
+
+  const _ActionsSection({required this.cache, required this.queue});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Card(
+      elevation: 1,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(UssdDesignSystem.radiusL),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(UssdDesignSystem.spacingL),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Actions',
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: UssdDesignSystem.spacingM),
+            OutlinedButton.icon(
+              onPressed: () async {
+                await cache.evictExpired();
+                if (context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Expired entries removed.')),
+                  );
+                }
+              },
+              icon: const Icon(Icons.cleaning_services_rounded),
+              label: const Text('Evict expired entries'),
+              style: OutlinedButton.styleFrom(
+                minimumSize: const Size(double.infinity, 48),
+              ),
+            ),
+            const SizedBox(height: UssdDesignSystem.spacingS),
+            FilledButton.icon(
+              onPressed: cache.entryCount == 0
+                  ? null
+                  : () => _confirmClear(
+                        context,
+                        title: 'Clear cache',
+                        message:
+                            'Remove all ${cache.entryCount} cached responses?',
+                        onConfirm: () => cache.clearAll(),
+                      ),
+              icon: const Icon(Icons.delete_sweep_rounded),
+              label: const Text('Clear all cache'),
+              style: FilledButton.styleFrom(
+                backgroundColor: colorScheme.error,
+                foregroundColor: colorScheme.onError,
+                minimumSize: const Size(double.infinity, 48),
+              ),
+            ),
+            const SizedBox(height: UssdDesignSystem.spacingS),
+            FilledButton.icon(
+              onPressed: queue.isEmpty
+                  ? null
+                  : () => _confirmClear(
+                        context,
+                        title: 'Clear queue',
+                        message:
+                            'Discard all ${queue.length} queued requests?',
+                        onConfirm: () => queue.clearAll(),
+                      ),
+              icon: const Icon(Icons.clear_all_rounded),
+              label: const Text('Clear offline queue'),
+              style: FilledButton.styleFrom(
+                backgroundColor: colorScheme.error,
+                foregroundColor: colorScheme.onError,
+                minimumSize: const Size(double.infinity, 48),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _confirmClear(
+    BuildContext context, {
+    required String title,
+    required String message,
+    required VoidCallback onConfirm,
+  }) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(UssdDesignSystem.radiusL),
+        ),
+        title: Text(title),
+        content: Text(message),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(context).colorScheme.error,
+              foregroundColor: Theme.of(context).colorScheme.onError,
+            ),
+            onPressed: () {
+              onConfirm();
+              Navigator.of(context).pop();
+            },
+            child: const Text('Clear'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/endpoint_config_screen.dart
+++ b/lib/screens/endpoint_config_screen.dart
@@ -4,6 +4,8 @@ import 'package:flutter_animate/flutter_animate.dart';
 import '../providers/ussd_provider.dart';
 import '../models/endpoint_config.dart';
 import '../utils/design_system.dart';
+import '../utils/page_transitions.dart';
+import 'cache_management_screen.dart';
 
 class EndpointConfigScreen extends StatelessWidget {
   const EndpointConfigScreen({super.key});
@@ -42,26 +44,49 @@ class EndpointConfigScreen extends StatelessWidget {
           Positioned(
             bottom: 24,
             right: 24,
-            child: FloatingActionButton.extended(
-              onPressed: () => _addEndpoint(context, provider),
-              icon: const Icon(Icons.add_rounded),
-              label: const Text('Add Endpoint'),
-              backgroundColor: Theme.of(context).colorScheme.primary,
-              foregroundColor: Theme.of(context).colorScheme.onPrimary,
-              elevation: 4,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(UssdDesignSystem.radiusL),
-              ),
-            )
-                .animate()
-                .scale(
-                  begin: const Offset(0.0, 0.0),
-                  end: const Offset(1.0, 1.0),
-                  duration: UssdDesignSystem.animationMedium,
-                  curve: Curves.elasticOut,
-                  delay: const Duration(milliseconds: 300),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                FloatingActionButton.small(
+                  heroTag: 'cache_fab',
+                  onPressed: () => Navigator.push(
+                    context,
+                    PageTransitions.slideFromRight(
+                      const CacheManagementScreen(),
+                    ),
+                  ),
+                  backgroundColor:
+                      Theme.of(context).colorScheme.secondaryContainer,
+                  foregroundColor:
+                      Theme.of(context).colorScheme.onSecondaryContainer,
+                  tooltip: 'Offline & Cache',
+                  child: const Icon(Icons.offline_bolt_rounded),
+                ),
+                const SizedBox(height: 12),
+                FloatingActionButton.extended(
+                  heroTag: 'add_endpoint_fab',
+                  onPressed: () => _addEndpoint(context, provider),
+                  icon: const Icon(Icons.add_rounded),
+                  label: const Text('Add Endpoint'),
+                  backgroundColor: Theme.of(context).colorScheme.primary,
+                  foregroundColor: Theme.of(context).colorScheme.onPrimary,
+                  elevation: 4,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(UssdDesignSystem.radiusL),
+                  ),
                 )
-                .fadeIn(delay: const Duration(milliseconds: 200)),
+                    .animate()
+                    .scale(
+                      begin: const Offset(0.0, 0.0),
+                      end: const Offset(1.0, 1.0),
+                      duration: UssdDesignSystem.animationMedium,
+                      curve: Curves.elasticOut,
+                      delay: const Duration(milliseconds: 300),
+                    )
+                    .fadeIn(delay: const Duration(milliseconds: 200)),
+              ],
+            ),
           ),
         ],
       ),

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -7,6 +7,7 @@ import '../providers/language_provider.dart';
 import '../providers/template_provider.dart';
 import '../utils/design_system.dart';
 import '../utils/page_transitions.dart' hide ScaleTransition;
+import '../widgets/offline_banner.dart';
 import '../l10n/generated/app_localizations.dart';
 import 'ussd_session_screen.dart';
 import 'endpoint_config_screen.dart';
@@ -256,6 +257,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                 ],
               ),
             ),
+            const OfflineBanner(),
             Expanded(
               child: AnimatedSwitcher(
                 duration: UssdDesignSystem.animationMedium,

--- a/lib/services/offline_queue_service.dart
+++ b/lib/services/offline_queue_service.dart
@@ -1,0 +1,146 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../models/ussd_request.dart';
+import '../models/endpoint_config.dart';
+
+/// A request that was made while offline and is waiting to be replayed.
+class QueuedRequest {
+  final String id;
+  final UssdRequest request;
+  final EndpointConfig config;
+  final DateTime timestamp;
+  int retryCount;
+  String? failureReason;
+
+  QueuedRequest({
+    required this.id,
+    required this.request,
+    required this.config,
+    required this.timestamp,
+    this.retryCount = 0,
+    this.failureReason,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'request': request.toJson(),
+    'config': config.toJson(),
+    'timestamp': timestamp.toIso8601String(),
+    'retryCount': retryCount,
+    'failureReason': failureReason,
+  };
+
+  factory QueuedRequest.fromJson(Map<String, dynamic> json) => QueuedRequest(
+    id: json['id'] as String,
+    request: UssdRequest.fromJson(json['request'] as Map<String, dynamic>),
+    config: EndpointConfig.fromJson(json['config'] as Map<String, dynamic>),
+    timestamp: DateTime.parse(json['timestamp'] as String),
+    retryCount: (json['retryCount'] as int?) ?? 0,
+    failureReason: json['failureReason'] as String?,
+  );
+}
+
+/// Persists offline requests across app restarts and replays them when
+/// connectivity is restored.
+class OfflineQueueService extends ChangeNotifier {
+  static const String _prefsKey = 'ussd_offline_queue';
+  static const int _maxRetries = 3;
+
+  SharedPreferences? _prefs;
+  final List<QueuedRequest> _queue = [];
+
+  int get length => _queue.length;
+  bool get isEmpty => _queue.isEmpty;
+  List<QueuedRequest> get items => List.unmodifiable(_queue);
+
+  Future<void> init() async {
+    _prefs = await SharedPreferences.getInstance();
+    _loadFromPrefs();
+  }
+
+  void _loadFromPrefs() {
+    final raw = _prefs?.getString(_prefsKey);
+    if (raw == null) return;
+
+    try {
+      final List<dynamic> decoded = jsonDecode(raw);
+      _queue.clear();
+      for (final item in decoded) {
+        try {
+          _queue.add(QueuedRequest.fromJson(item as Map<String, dynamic>));
+        } catch (_) {
+          // Skip malformed entries
+        }
+      }
+    } catch (e) {
+      debugPrint('OfflineQueueService: failed to load queue: $e');
+    }
+  }
+
+  Future<void> _saveToPrefs() async {
+    try {
+      final encoded = jsonEncode(_queue.map((r) => r.toJson()).toList());
+      await _prefs?.setString(_prefsKey, encoded);
+    } catch (e) {
+      debugPrint('OfflineQueueService: failed to save queue: $e');
+    }
+  }
+
+  /// Add a request to the queue.
+  Future<void> enqueue(UssdRequest request, EndpointConfig config) async {
+    final queued = QueuedRequest(
+      id: '${DateTime.now().millisecondsSinceEpoch}_${request.sessionId}',
+      request: request,
+      config: config,
+      timestamp: DateTime.now(),
+    );
+    _queue.add(queued);
+    await _saveToPrefs();
+    notifyListeners();
+  }
+
+  /// Process the queue by calling [executor] for each item.
+  /// Items that succeed are removed; items that fail are retried up to
+  /// [_maxRetries] times before being marked as failed and dropped.
+  Future<void> processQueue(
+    Future<void> Function(QueuedRequest) executor,
+  ) async {
+    if (_queue.isEmpty) return;
+
+    final toProcess = List<QueuedRequest>.from(_queue);
+    for (final item in toProcess) {
+      try {
+        await executor(item);
+        _queue.remove(item);
+      } catch (e) {
+        item.retryCount++;
+        item.failureReason = e.toString();
+        if (item.retryCount >= _maxRetries) {
+          debugPrint(
+            'OfflineQueueService: dropping request ${item.id} after '
+            '$_maxRetries retries: $e',
+          );
+          _queue.remove(item);
+        }
+      }
+    }
+
+    await _saveToPrefs();
+    notifyListeners();
+  }
+
+  /// Remove a specific item from the queue.
+  Future<void> remove(String id) async {
+    _queue.removeWhere((r) => r.id == id);
+    await _saveToPrefs();
+    notifyListeners();
+  }
+
+  /// Clear the entire queue.
+  Future<void> clearAll() async {
+    _queue.clear();
+    await _prefs?.remove(_prefsKey);
+    notifyListeners();
+  }
+}

--- a/lib/services/ussd_cache_service.dart
+++ b/lib/services/ussd_cache_service.dart
@@ -1,0 +1,166 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../models/ussd_request.dart';
+import '../models/ussd_response.dart';
+
+/// A single cached response entry with TTL metadata.
+class CacheEntry {
+  final UssdResponse response;
+  final DateTime timestamp;
+  final Duration ttl;
+  int hitCount;
+
+  CacheEntry({
+    required this.response,
+    required this.timestamp,
+    required this.ttl,
+    this.hitCount = 0,
+  });
+
+  bool get isExpired => DateTime.now().difference(timestamp) > ttl;
+
+  Map<String, dynamic> toJson() => {
+    'response': response.toJson(),
+    'timestamp': timestamp.toIso8601String(),
+    'ttlMs': ttl.inMilliseconds,
+    'hitCount': hitCount,
+  };
+
+  factory CacheEntry.fromJson(Map<String, dynamic> json) => CacheEntry(
+    response: UssdResponse.fromJson(
+      json['response'] as Map<String, dynamic>,
+    ),
+    timestamp: DateTime.parse(json['timestamp'] as String),
+    ttl: Duration(milliseconds: json['ttlMs'] as int),
+    hitCount: (json['hitCount'] as int?) ?? 0,
+  );
+}
+
+/// Persists USSD responses keyed by (serviceCode, text, phoneNumber).
+/// Uses shared_preferences — no additional dependencies required.
+class UssdCacheService extends ChangeNotifier {
+  static const String _prefsKey = 'ussd_response_cache';
+  static const Duration defaultTtl = Duration(hours: 24);
+
+  SharedPreferences? _prefs;
+  final Map<String, CacheEntry> _cache = {};
+
+  int _totalRequests = 0;
+  int _cacheHits = 0;
+
+  int get entryCount => _cache.length;
+  int get totalRequests => _totalRequests;
+  int get cacheHits => _cacheHits;
+  double get hitRate =>
+      _totalRequests == 0 ? 0.0 : (_cacheHits / _totalRequests) * 100;
+
+  Future<void> init() async {
+    _prefs = await SharedPreferences.getInstance();
+    _loadFromPrefs();
+  }
+
+  void _loadFromPrefs() {
+    final raw = _prefs?.getString(_prefsKey);
+    if (raw == null) return;
+
+    try {
+      final Map<String, dynamic> decoded = jsonDecode(raw);
+      _cache.clear();
+      for (final entry in decoded.entries) {
+        try {
+          final cacheEntry = CacheEntry.fromJson(
+            entry.value as Map<String, dynamic>,
+          );
+          if (!cacheEntry.isExpired) {
+            _cache[entry.key] = cacheEntry;
+          }
+        } catch (_) {
+          // Skip malformed entries
+        }
+      }
+    } catch (e) {
+      debugPrint('UssdCacheService: failed to load cache: $e');
+    }
+  }
+
+  Future<void> _saveToPrefs() async {
+    try {
+      final encoded = jsonEncode(
+        _cache.map((k, v) => MapEntry(k, v.toJson())),
+      );
+      await _prefs?.setString(_prefsKey, encoded);
+    } catch (e) {
+      debugPrint('UssdCacheService: failed to save cache: $e');
+    }
+  }
+
+  String _cacheKey(UssdRequest request) =>
+      '${request.serviceCode}:${request.text}:${request.phoneNumber}';
+
+  /// Store a response in the cache.
+  Future<void> cacheResponse(
+    UssdRequest request,
+    UssdResponse response, {
+    Duration? ttl,
+  }) async {
+    final key = _cacheKey(request);
+    _cache[key] = CacheEntry(
+      response: response,
+      timestamp: DateTime.now(),
+      ttl: ttl ?? defaultTtl,
+    );
+    await _saveToPrefs();
+    notifyListeners();
+  }
+
+  /// Return a cached response if one exists and has not expired.
+  /// Returns null on a miss.
+  Future<UssdResponse?> getCachedResponse(UssdRequest request) async {
+    _totalRequests++;
+    final key = _cacheKey(request);
+    final entry = _cache[key];
+
+    if (entry == null) return null;
+
+    if (entry.isExpired) {
+      _cache.remove(key);
+      await _saveToPrefs();
+      notifyListeners();
+      return null;
+    }
+
+    entry.hitCount++;
+    _cacheHits++;
+    notifyListeners();
+    return entry.response;
+  }
+
+  /// Remove all expired entries and persist.
+  Future<void> evictExpired() async {
+    final expired = _cache.entries
+        .where((e) => e.value.isExpired)
+        .map((e) => e.key)
+        .toList();
+    for (final key in expired) {
+      _cache.remove(key);
+    }
+    if (expired.isNotEmpty) {
+      await _saveToPrefs();
+      notifyListeners();
+    }
+  }
+
+  /// Clear the entire cache.
+  Future<void> clearAll() async {
+    _cache.clear();
+    _totalRequests = 0;
+    _cacheHits = 0;
+    await _prefs?.remove(_prefsKey);
+    notifyListeners();
+  }
+
+  /// Snapshot of all current (non-expired) entries for display.
+  List<MapEntry<String, CacheEntry>> get entries =>
+      _cache.entries.where((e) => !e.value.isExpired).toList();
+}

--- a/lib/widgets/animated_message_bubble.dart
+++ b/lib/widgets/animated_message_bubble.dart
@@ -3,6 +3,7 @@ import 'package:flutter_animate/flutter_animate.dart';
 import '../models/ussd_response.dart';
 import '../models/ussd_request.dart';
 import '../utils/design_system.dart';
+import 'offline_banner.dart';
 
 /// Enhanced animated message bubble with slide and fade transitions
 class AnimatedMessageBubble extends StatelessWidget {
@@ -11,6 +12,7 @@ class AnimatedMessageBubble extends StatelessWidget {
   final bool isUser;
   final int index;
   final VoidCallback? onTap;
+  final bool fromCache;
 
   const AnimatedMessageBubble({
     Key? key,
@@ -19,6 +21,7 @@ class AnimatedMessageBubble extends StatelessWidget {
     required this.isUser,
     required this.index,
     this.onTap,
+    this.fromCache = false,
   }) : super(key: key);
 
   @override
@@ -83,7 +86,13 @@ class AnimatedMessageBubble extends StatelessWidget {
     if (isUser) {
       return _buildUserMessage(context, colorScheme, textTheme, messageText);
     } else {
-      return _buildSystemMessage(context, colorScheme, textTheme, messageText);
+      return _buildSystemMessage(
+        context,
+        colorScheme,
+        textTheme,
+        messageText,
+        fromCache: fromCache,
+      );
     }
   }
 
@@ -122,8 +131,9 @@ class AnimatedMessageBubble extends StatelessWidget {
     BuildContext context,
     ColorScheme colorScheme,
     TextTheme textTheme,
-    String messageText,
-  ) {
+    String messageText, {
+    bool fromCache = false,
+  }) {
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
@@ -169,6 +179,10 @@ class AnimatedMessageBubble extends StatelessWidget {
                   duration: UssdDesignSystem.animationFast,
                   delay: UssdDesignSystem.animationMedium,
                 ),
+                if (fromCache) ...[
+                  const SizedBox(width: UssdDesignSystem.spacingS),
+                  const CacheHitChip(),
+                ],
               ],
             ),
             const SizedBox(height: 12),

--- a/lib/widgets/modern_conversation_view.dart
+++ b/lib/widgets/modern_conversation_view.dart
@@ -9,6 +9,7 @@ import '../utils/ussd_utils.dart';
 import '../utils/design_system.dart';
 import '../widgets/animated_message_bubble.dart';
 import '../widgets/modern_input_field.dart';
+import '../widgets/offline_banner.dart';
 import '../l10n/generated/app_localizations.dart';
 import 'ussd_keypad.dart';
 import 'ussd_debug_panel.dart';
@@ -297,6 +298,11 @@ class _ModernUssdConversationViewState extends State<ModernUssdConversationView>
             final request = index < session.requests.length
                 ? session.requests[index]
                 : null;
+            final isLastResponse =
+                index == session.responses.length - 1;
+            final provider = context.read<UssdProvider>();
+            final fromCache =
+                isLastResponse && provider.lastResponseFromCache;
 
             return AnimationConfiguration.staggeredList(
               position: index,
@@ -315,6 +321,7 @@ class _ModernUssdConversationViewState extends State<ModernUssdConversationView>
                     response: response,
                     isUser: false,
                     index: index * 2 + 1,
+                    fromCache: fromCache,
                     onTap: () {
                       accessibilityProvider.speak(response.text);
                     },

--- a/lib/widgets/offline_banner.dart
+++ b/lib/widgets/offline_banner.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:flutter_animate/flutter_animate.dart';
+import '../providers/ussd_provider.dart';
+import '../utils/design_system.dart';
+
+/// A slim banner shown at the top of the screen when the device is offline.
+/// Displays the number of queued requests and disappears when back online.
+class OfflineBanner extends StatelessWidget {
+  const OfflineBanner({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = context.watch<UssdProvider>();
+
+    if (!provider.isOffline) return const SizedBox.shrink();
+
+    final colorScheme = Theme.of(context).colorScheme;
+    final queueCount = provider.queuedRequestCount;
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(
+        vertical: UssdDesignSystem.spacingS,
+        horizontal: UssdDesignSystem.spacingM,
+      ),
+      decoration: BoxDecoration(
+        color: colorScheme.errorContainer,
+        border: Border(
+          bottom: BorderSide(
+            color: colorScheme.error.withOpacity(0.3),
+            width: 1,
+          ),
+        ),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            Icons.cloud_off_rounded,
+            size: 16,
+            color: colorScheme.onErrorContainer,
+          ),
+          const SizedBox(width: UssdDesignSystem.spacingS),
+          Expanded(
+            child: Text(
+              queueCount > 0
+                  ? 'Offline — $queueCount request${queueCount == 1 ? '' : 's'} queued'
+                  : 'Offline — requests will be queued until reconnected',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: colorScheme.onErrorContainer,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+          if (queueCount > 0)
+            Container(
+              padding: const EdgeInsets.symmetric(
+                horizontal: UssdDesignSystem.spacingS,
+                vertical: 2,
+              ),
+              decoration: BoxDecoration(
+                color: colorScheme.error,
+                borderRadius: BorderRadius.circular(UssdDesignSystem.radiusM),
+              ),
+              child: Text(
+                '$queueCount',
+                style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                  color: colorScheme.onError,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+        ],
+      ),
+    )
+        .animate()
+        .slideY(
+          begin: -1.0,
+          end: 0.0,
+          duration: UssdDesignSystem.animationMedium,
+          curve: UssdDesignSystem.curveDefault,
+        )
+        .fadeIn(duration: UssdDesignSystem.animationMedium);
+  }
+}
+
+/// A small chip shown on a cached response bubble to indicate it came from
+/// the local cache rather than a live network call.
+class CacheHitChip extends StatelessWidget {
+  const CacheHitChip({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: UssdDesignSystem.spacingS,
+        vertical: 2,
+      ),
+      decoration: BoxDecoration(
+        color: colorScheme.tertiaryContainer,
+        borderRadius: BorderRadius.circular(UssdDesignSystem.radiusS),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.offline_bolt_rounded,
+            size: 10,
+            color: colorScheme.onTertiaryContainer,
+          ),
+          const SizedBox(width: 3),
+          Text(
+            'cached',
+            style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: colorScheme.onTertiaryContainer,
+              fontSize: 9,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Closes #12

## What this adds

### Services (no new dependencies — uses existing `shared_preferences`)

**`UssdCacheService`**
- Caches USSD responses keyed by `serviceCode:text:phoneNumber`
- Configurable TTL per entry (default 24h); expired entries are evicted lazily on read or explicitly via `evictExpired()`
- Tracks hit count per entry and overall hit rate
- Persists across app restarts via `shared_preferences`

**`OfflineQueueService`**
- Persists queued requests across app restarts
- `processQueue()` replays items when called; drops an item after 3 consecutive failures
- Per-item removal supported from the UI

### Provider changes (`UssdProvider`)

`sendUssdInput` now follows an offline-first strategy:

| Condition | Behaviour |
|---|---|
| Offline + cache hit | Return cached response, mark `lastResponseFromCache = true` |
| Offline + no cache | Queue request, return a user-visible placeholder response |
| Online, request succeeds | Cache the response, return it |
| Online, request fails + cache hit | Return cached response |
| Online, request fails + no cache | Queue request, rethrow |

`ConnectivityService` is listened to; when connectivity is restored the queue is automatically processed and results are cached.

Constructor parameters (`connectivityService`, `cacheService`, `queueService`) are **optional** — existing tests that call `UssdProvider()` with no args continue to work.

### UI

- **`OfflineBanner`** — animated slide-in bar at the top of the screen when offline; shows queued request count badge
- **`CacheHitChip`** — small "cached" chip shown on system message bubbles when the response came from cache
- **`CacheManagementScreen`** — accessible via a floating button on the Config tab; shows cache stats, lists cached entries with expiry/hit counts, lists queued requests with per-item removal, and provides evict/clear actions

## Design decisions

- **No Hive** — the issue proposed Hive but `shared_preferences` is already a dependency and sufficient for the data volumes involved (USSD responses are small text strings). Avoids adding a code-generation dependency.
- **Queue is fire-and-forget** — queued requests are replayed silently in the background; there is no per-request success notification to the user (the session that triggered the queue is already ended by the time connectivity returns).
- **Cache is not invalidated on session end** — cached responses remain valid across sessions for the configured TTL. This is intentional: the cache is for repeated testing of the same USSD flow.

## Files changed

| File | Change |
|---|---|
| `lib/services/ussd_cache_service.dart` | New — response cache |
| `lib/services/offline_queue_service.dart` | New — offline request queue |
| `lib/screens/cache_management_screen.dart` | New — cache/queue management UI |
| `lib/widgets/offline_banner.dart` | New — `OfflineBanner` + `CacheHitChip` |
| `lib/providers/ussd_provider.dart` | Offline-first send logic, queue auto-processing |
| `lib/main.dart` | Register new providers; wire into `UssdProvider` |
| `lib/screens/home_screen.dart` | Add `OfflineBanner` |
| `lib/screens/endpoint_config_screen.dart` | Add cache management FAB |
| `lib/widgets/animated_message_bubble.dart` | `fromCache` param + `CacheHitChip`; fix `TypingIndicator` repeat |
| `lib/widgets/modern_conversation_view.dart` | Pass `fromCache` to last response bubble |