### PR TITLE
feat(analytics): session analytics and performance monitoring (issue #7)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'screens/home_screen.dart';
 import 'services/connectivity_service.dart';
 import 'services/ussd_cache_service.dart';
 import 'services/offline_queue_service.dart';
+import 'services/analytics_service.dart';
 import 'utils/accessibility_themes.dart';
 import 'utils/design_system.dart';
 import 'l10n/generated/app_localizations.dart';
@@ -27,19 +28,22 @@ class UssdEmulatorApp extends StatelessWidget {
         ChangeNotifierProvider(create: (context) => ConnectivityService()),
         ChangeNotifierProvider(create: (context) => UssdCacheService()),
         ChangeNotifierProvider(create: (context) => OfflineQueueService()),
-        ChangeNotifierProxyProvider3<ConnectivityService, UssdCacheService,
-            OfflineQueueService, UssdProvider>(
+        ChangeNotifierProvider(create: (context) => AnalyticsService()),
+        ChangeNotifierProxyProvider4<ConnectivityService, UssdCacheService,
+            OfflineQueueService, AnalyticsService, UssdProvider>(
           create: (context) => UssdProvider(
             connectivityService: context.read<ConnectivityService>(),
             cacheService: context.read<UssdCacheService>(),
             queueService: context.read<OfflineQueueService>(),
+            analyticsService: context.read<AnalyticsService>(),
           ),
-          update: (context, connectivity, cache, queue, previous) =>
+          update: (context, connectivity, cache, queue, analytics, previous) =>
               previous ??
               UssdProvider(
                 connectivityService: connectivity,
                 cacheService: cache,
                 queueService: queue,
+                analyticsService: analytics,
               ),
         ),
 

--- a/lib/models/analytics_models.dart
+++ b/lib/models/analytics_models.dart
@@ -1,0 +1,129 @@
+/// Analytics data models — no code generation needed, plain JSON serialization.
+
+enum SessionEventType { sessionStart, sessionEnd, requestSent, responseReceived, error }
+
+class SessionEvent {
+  final String id;
+  final SessionEventType type;
+  final DateTime timestamp;
+  final String sessionId;
+  final String serviceCode;
+  final String endpointName;
+  final Map<String, dynamic> metadata;
+
+  const SessionEvent({
+    required this.id,
+    required this.type,
+    required this.timestamp,
+    required this.sessionId,
+    required this.serviceCode,
+    required this.endpointName,
+    this.metadata = const {},
+  });
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'type': type.name,
+    'timestamp': timestamp.toIso8601String(),
+    'sessionId': sessionId,
+    'serviceCode': serviceCode,
+    'endpointName': endpointName,
+    'metadata': metadata,
+  };
+
+  factory SessionEvent.fromJson(Map<String, dynamic> json) => SessionEvent(
+    id: json['id'] as String,
+    type: SessionEventType.values.firstWhere(
+      (e) => e.name == json['type'],
+      orElse: () => SessionEventType.error,
+    ),
+    timestamp: DateTime.parse(json['timestamp'] as String),
+    sessionId: json['sessionId'] as String,
+    serviceCode: json['serviceCode'] as String,
+    endpointName: json['endpointName'] as String,
+    metadata: Map<String, dynamic>.from(
+      (json['metadata'] as Map?)?.cast<String, dynamic>() ?? {},
+    ),
+  );
+}
+
+class ResponseMetric {
+  final String id;
+  final String sessionId;
+  final String endpointName;
+  final String serviceCode;
+  final int responseTimeMs;
+  final bool success;
+  final String? errorMessage;
+  final DateTime timestamp;
+
+  const ResponseMetric({
+    required this.id,
+    required this.sessionId,
+    required this.endpointName,
+    required this.serviceCode,
+    required this.responseTimeMs,
+    required this.success,
+    this.errorMessage,
+    required this.timestamp,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'sessionId': sessionId,
+    'endpointName': endpointName,
+    'serviceCode': serviceCode,
+    'responseTimeMs': responseTimeMs,
+    'success': success,
+    'errorMessage': errorMessage,
+    'timestamp': timestamp.toIso8601String(),
+  };
+
+  factory ResponseMetric.fromJson(Map<String, dynamic> json) => ResponseMetric(
+    id: json['id'] as String,
+    sessionId: json['sessionId'] as String,
+    endpointName: json['endpointName'] as String,
+    serviceCode: json['serviceCode'] as String,
+    responseTimeMs: json['responseTimeMs'] as int,
+    success: json['success'] as bool,
+    errorMessage: json['errorMessage'] as String?,
+    timestamp: DateTime.parse(json['timestamp'] as String),
+  );
+}
+
+/// Computed summary derived from raw events and metrics.
+class AnalyticsSummary {
+  final int totalSessions;
+  final int totalRequests;
+  final int totalErrors;
+  final double avgResponseTimeMs;
+  final double errorRate;
+  final Map<String, int> sessionsByServiceCode;
+  final Map<String, double> avgResponseTimeByEndpoint;
+  final Map<String, int> errorsByEndpoint;
+  final Duration totalSessionDuration;
+
+  const AnalyticsSummary({
+    required this.totalSessions,
+    required this.totalRequests,
+    required this.totalErrors,
+    required this.avgResponseTimeMs,
+    required this.errorRate,
+    required this.sessionsByServiceCode,
+    required this.avgResponseTimeByEndpoint,
+    required this.errorsByEndpoint,
+    required this.totalSessionDuration,
+  });
+
+  static AnalyticsSummary empty() => const AnalyticsSummary(
+    totalSessions: 0,
+    totalRequests: 0,
+    totalErrors: 0,
+    avgResponseTimeMs: 0,
+    errorRate: 0,
+    sessionsByServiceCode: {},
+    avgResponseTimeByEndpoint: {},
+    errorsByEndpoint: {},
+    totalSessionDuration: Duration.zero,
+  );
+}

--- a/lib/providers/ussd_provider.dart
+++ b/lib/providers/ussd_provider.dart
@@ -9,6 +9,7 @@ import '../services/endpoint_config_service.dart';
 import '../services/connectivity_service.dart';
 import '../services/ussd_cache_service.dart';
 import '../services/offline_queue_service.dart';
+import '../services/analytics_service.dart';
 import '../utils/ussd_utils.dart';
 
 class UssdProvider with ChangeNotifier {
@@ -19,14 +20,17 @@ class UssdProvider with ChangeNotifier {
   final ConnectivityService _connectivityService;
   final UssdCacheService _cacheService;
   final OfflineQueueService _queueService;
+  final AnalyticsService _analyticsService;
 
   UssdProvider({
     ConnectivityService? connectivityService,
     UssdCacheService? cacheService,
     OfflineQueueService? queueService,
+    AnalyticsService? analyticsService,
   })  : _connectivityService = connectivityService ?? ConnectivityService(),
         _cacheService = cacheService ?? UssdCacheService(),
-        _queueService = queueService ?? OfflineQueueService() {
+        _queueService = queueService ?? OfflineQueueService(),
+        _analyticsService = analyticsService ?? AnalyticsService() {
     _connectivityService.addListener(_onConnectivityChanged);
   }
 
@@ -49,6 +53,7 @@ class UssdProvider with ChangeNotifier {
 
   UssdCacheService get cacheService => _cacheService;
   OfflineQueueService get queueService => _queueService;
+  AnalyticsService get analyticsService => _analyticsService;
 
   Future<void> init() async {
     if (_isInitialized) return;
@@ -61,6 +66,7 @@ class UssdProvider with ChangeNotifier {
         _connectivityService.init(),
         _cacheService.init(),
         _queueService.init(),
+        _analyticsService.init(),
       ]);
       _isInitialized = true;
       _clearError();
@@ -86,6 +92,14 @@ class UssdProvider with ChangeNotifier {
         networkCode: networkCode,
       );
       notifyListeners();
+      // Track after session is created so we have the session ID.
+      if (currentSession != null) {
+        await _analyticsService.trackSessionStart(
+          sessionId: currentSession!.id,
+          serviceCode: serviceCode,
+          endpointName: activeEndpointConfig?.name ?? 'unknown',
+        );
+      }
     } catch (e) {
       _setError('Failed to start session: ${e.toString()}');
     } finally {
@@ -165,11 +179,33 @@ class UssdProvider with ChangeNotifier {
       );
     }
 
+    final timerId = _analyticsService.startTimer();
     try {
       final response = await _apiService.sendUssdRequest(request, config);
+      await _analyticsService.endTimer(
+        timerId: timerId,
+        sessionId: request.sessionId,
+        endpointName: config.name,
+        serviceCode: request.serviceCode,
+        success: true,
+      );
       await _cacheService.cacheResponse(request, response);
       return response;
     } catch (e) {
+      await _analyticsService.endTimer(
+        timerId: timerId,
+        sessionId: request.sessionId,
+        endpointName: config.name,
+        serviceCode: request.serviceCode,
+        success: false,
+        errorMessage: e.toString(),
+      );
+      await _analyticsService.trackError(
+        sessionId: request.sessionId,
+        serviceCode: request.serviceCode,
+        endpointName: config.name,
+        error: e.toString(),
+      );
       final cached = await _cacheService.getCachedResponse(request);
       if (cached != null) {
         _lastResponseFromCache = true;
@@ -202,9 +238,20 @@ class UssdProvider with ChangeNotifier {
     _setLoading(true);
     _clearError();
 
+    // Capture before the session is cleared.
+    final session = currentSession;
+
     try {
       await _sessionService.endSession();
       notifyListeners();
+      if (session != null) {
+        await _analyticsService.trackSessionEnd(
+          sessionId: session.id,
+          serviceCode: session.serviceCode,
+          endpointName: activeEndpointConfig?.name ?? 'unknown',
+          messageCount: session.responses.length,
+        );
+      }
     } catch (e) {
       _setError('Failed to end session: ${e.toString()}');
     } finally {

--- a/lib/screens/analytics_dashboard_screen.dart
+++ b/lib/screens/analytics_dashboard_screen.dart
@@ -1,0 +1,721 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:provider/provider.dart';
+import 'package:flutter_animate/flutter_animate.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:share_plus/share_plus.dart';
+import '../services/analytics_service.dart';
+import '../models/analytics_models.dart';
+import '../utils/design_system.dart';
+
+class AnalyticsDashboardScreen extends StatelessWidget {
+  const AnalyticsDashboardScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final analytics = context.watch<AnalyticsService>();
+    final summary = analytics.computeSummary();
+
+    return SafeArea(
+      child: ListView(
+        padding: const EdgeInsets.symmetric(
+          horizontal: UssdDesignSystem.spacingM,
+          vertical: UssdDesignSystem.spacingM,
+        ),
+        children: [
+          _SummaryRow(summary: summary)
+              .animate()
+              .fadeIn(duration: UssdDesignSystem.animationMedium)
+              .slideY(begin: 0.2, end: 0.0),
+          const SizedBox(height: UssdDesignSystem.spacingM),
+          _ResponseTimeCard(summary: summary, metrics: analytics.metrics)
+              .animate(delay: const Duration(milliseconds: 80))
+              .fadeIn(duration: UssdDesignSystem.animationMedium)
+              .slideY(begin: 0.2, end: 0.0),
+          const SizedBox(height: UssdDesignSystem.spacingM),
+          _TopServiceCodesCard(summary: summary)
+              .animate(delay: const Duration(milliseconds: 160))
+              .fadeIn(duration: UssdDesignSystem.animationMedium)
+              .slideY(begin: 0.2, end: 0.0),
+          const SizedBox(height: UssdDesignSystem.spacingM),
+          _EndpointPerformanceCard(summary: summary)
+              .animate(delay: const Duration(milliseconds: 240))
+              .fadeIn(duration: UssdDesignSystem.animationMedium)
+              .slideY(begin: 0.2, end: 0.0),
+          const SizedBox(height: UssdDesignSystem.spacingM),
+          _RecentErrorsCard(events: analytics.events)
+              .animate(delay: const Duration(milliseconds: 320))
+              .fadeIn(duration: UssdDesignSystem.animationMedium)
+              .slideY(begin: 0.2, end: 0.0),
+          const SizedBox(height: UssdDesignSystem.spacingM),
+          _ActionsCard(analytics: analytics)
+              .animate(delay: const Duration(milliseconds: 400))
+              .fadeIn(duration: UssdDesignSystem.animationMedium)
+              .slideY(begin: 0.2, end: 0.0),
+          const SizedBox(height: UssdDesignSystem.spacingXXL),
+        ],
+      ),
+    );
+  }
+}
+
+// ── Summary row ──────────────────────────────────────────────────────────────
+
+class _SummaryRow extends StatelessWidget {
+  final AnalyticsSummary summary;
+  const _SummaryRow({required this.summary});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Row(
+      children: [
+        Expanded(
+          child: _StatCard(
+            icon: Icons.phone_in_talk_rounded,
+            label: 'Sessions',
+            value: '${summary.totalSessions}',
+            color: colorScheme.primary,
+          ),
+        ),
+        const SizedBox(width: UssdDesignSystem.spacingS),
+        Expanded(
+          child: _StatCard(
+            icon: Icons.send_rounded,
+            label: 'Requests',
+            value: '${summary.totalRequests}',
+            color: colorScheme.secondary,
+          ),
+        ),
+        const SizedBox(width: UssdDesignSystem.spacingS),
+        Expanded(
+          child: _StatCard(
+            icon: Icons.error_outline_rounded,
+            label: 'Errors',
+            value: '${summary.totalErrors}',
+            color: summary.totalErrors > 0
+                ? colorScheme.error
+                : colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(width: UssdDesignSystem.spacingS),
+        Expanded(
+          child: _StatCard(
+            icon: Icons.timer_outlined,
+            label: 'Avg ms',
+            value: summary.avgResponseTimeMs == 0
+                ? '—'
+                : '${summary.avgResponseTimeMs.round()}',
+            color: colorScheme.tertiary,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _StatCard extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final String value;
+  final Color color;
+
+  const _StatCard({
+    required this.icon,
+    required this.label,
+    required this.value,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 1,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(UssdDesignSystem.radiusL),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          vertical: UssdDesignSystem.spacingM,
+          horizontal: UssdDesignSystem.spacingS,
+        ),
+        child: Column(
+          children: [
+            Icon(icon, color: color, size: 22),
+            const SizedBox(height: UssdDesignSystem.spacingXS),
+            Text(
+              value,
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                color: color,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            Text(
+              label,
+              style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── Response time card ───────────────────────────────────────────────────────
+
+class _ResponseTimeCard extends StatelessWidget {
+  final AnalyticsSummary summary;
+  final List<ResponseMetric> metrics;
+
+  const _ResponseTimeCard({required this.summary, required this.metrics});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final recent = metrics.reversed.take(20).toList().reversed.toList();
+
+    return _DashCard(
+      icon: Icons.speed_rounded,
+      title: 'Response Times',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              _MetricPill(
+                label: 'Avg',
+                value: summary.avgResponseTimeMs == 0
+                    ? '—'
+                    : '${summary.avgResponseTimeMs.round()} ms',
+                color: colorScheme.primary,
+              ),
+              const SizedBox(width: UssdDesignSystem.spacingS),
+              _MetricPill(
+                label: 'Error rate',
+                value: '${summary.errorRate.toStringAsFixed(1)}%',
+                color: summary.errorRate > 10
+                    ? colorScheme.error
+                    : colorScheme.secondary,
+              ),
+              const SizedBox(width: UssdDesignSystem.spacingS),
+              _MetricPill(
+                label: 'Total time',
+                value: _formatDuration(summary.totalSessionDuration),
+                color: colorScheme.tertiary,
+              ),
+            ],
+          ),
+          if (recent.isNotEmpty) ...[
+            const SizedBox(height: UssdDesignSystem.spacingM),
+            Text(
+              'Last ${recent.length} requests',
+              style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: UssdDesignSystem.spacingS),
+            _ResponseTimeBar(metrics: recent),
+          ] else
+            Padding(
+              padding: const EdgeInsets.only(top: UssdDesignSystem.spacingM),
+              child: Text(
+                'No requests recorded yet.',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  String _formatDuration(Duration d) {
+    if (d.inHours > 0) return '${d.inHours}h ${d.inMinutes.remainder(60)}m';
+    if (d.inMinutes > 0) return '${d.inMinutes}m ${d.inSeconds.remainder(60)}s';
+    return '${d.inSeconds}s';
+  }
+}
+
+class _ResponseTimeBar extends StatelessWidget {
+  final List<ResponseMetric> metrics;
+  const _ResponseTimeBar({required this.metrics});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final maxMs = metrics.map((m) => m.responseTimeMs).fold(1, (a, b) => a > b ? a : b);
+
+    return SizedBox(
+      height: 48,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: metrics.map((m) {
+          final frac = maxMs == 0 ? 0.0 : m.responseTimeMs / maxMs;
+          return Expanded(
+            child: Tooltip(
+              message: '${m.responseTimeMs} ms\n${m.serviceCode}',
+              child: Container(
+                margin: const EdgeInsets.symmetric(horizontal: 1),
+                height: 8 + (40 * frac),
+                decoration: BoxDecoration(
+                  color: m.success ? colorScheme.primary : colorScheme.error,
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+            ),
+          );
+        }).toList(),
+      ),
+    );
+  }
+}
+
+// ── Top service codes ────────────────────────────────────────────────────────
+
+class _TopServiceCodesCard extends StatelessWidget {
+  final AnalyticsSummary summary;
+  const _TopServiceCodesCard({required this.summary});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final sorted = summary.sessionsByServiceCode.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    final top = sorted.take(5).toList();
+    final total = summary.totalSessions == 0 ? 1 : summary.totalSessions;
+
+    return _DashCard(
+      icon: Icons.dialpad_rounded,
+      title: 'Top Service Codes',
+      child: top.isEmpty
+          ? Text(
+              'No sessions recorded yet.',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: colorScheme.onSurfaceVariant,
+              ),
+            )
+          : Column(
+              children: top.map((entry) {
+                final frac = entry.value / total;
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: UssdDesignSystem.spacingS),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              entry.key,
+                              style: Theme.of(context).textTheme.bodyMedium
+                                  ?.copyWith(fontWeight: FontWeight.w600),
+                            ),
+                          ),
+                          Text(
+                            '${entry.value} session${entry.value == 1 ? '' : 's'}',
+                            style: Theme.of(context).textTheme.bodySmall
+                                ?.copyWith(color: colorScheme.onSurfaceVariant),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 4),
+                      ClipRRect(
+                        borderRadius: BorderRadius.circular(4),
+                        child: LinearProgressIndicator(
+                          value: frac,
+                          minHeight: 6,
+                          backgroundColor: colorScheme.surfaceContainerHighest,
+                          valueColor: AlwaysStoppedAnimation(colorScheme.primary),
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              }).toList(),
+            ),
+    );
+  }
+}
+
+// ── Endpoint performance ─────────────────────────────────────────────────────
+
+class _EndpointPerformanceCard extends StatelessWidget {
+  final AnalyticsSummary summary;
+  const _EndpointPerformanceCard({required this.summary});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final endpoints = summary.avgResponseTimeByEndpoint.entries.toList()
+      ..sort((a, b) => a.value.compareTo(b.value));
+
+    return _DashCard(
+      icon: Icons.cloud_rounded,
+      title: 'Endpoint Performance',
+      child: endpoints.isEmpty
+          ? Text(
+              'No endpoint data yet.',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: colorScheme.onSurfaceVariant,
+              ),
+            )
+          : Column(
+              children: endpoints.map((entry) {
+                final errors = summary.errorsByEndpoint[entry.key] ?? 0;
+                final avgMs = entry.value.round();
+                final isSlowish = avgMs > 2000;
+                return ListTile(
+                  contentPadding: EdgeInsets.zero,
+                  dense: true,
+                  leading: Icon(
+                    Icons.circle,
+                    size: 10,
+                    color: isSlowish ? colorScheme.error : colorScheme.secondary,
+                  ),
+                  title: Text(
+                    entry.key,
+                    style: Theme.of(context).textTheme.bodyMedium
+                        ?.copyWith(fontWeight: FontWeight.w500),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  trailing: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        '$avgMs ms',
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: isSlowish
+                              ? colorScheme.error
+                              : colorScheme.onSurface,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      if (errors > 0) ...[
+                        const SizedBox(width: UssdDesignSystem.spacingS),
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 6,
+                            vertical: 2,
+                          ),
+                          decoration: BoxDecoration(
+                            color: colorScheme.errorContainer,
+                            borderRadius: BorderRadius.circular(
+                              UssdDesignSystem.radiusS,
+                            ),
+                          ),
+                          child: Text(
+                            '$errors err',
+                            style: Theme.of(context).textTheme.labelSmall
+                                ?.copyWith(color: colorScheme.onErrorContainer),
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                );
+              }).toList(),
+            ),
+    );
+  }
+}
+
+// ── Recent errors ────────────────────────────────────────────────────────────
+
+class _RecentErrorsCard extends StatelessWidget {
+  final List<SessionEvent> events;
+  const _RecentErrorsCard({required this.events});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final errors = events
+        .where((e) => e.type == SessionEventType.error)
+        .toList()
+        .reversed
+        .take(5)
+        .toList();
+
+    return _DashCard(
+      icon: Icons.warning_amber_rounded,
+      title: 'Recent Errors',
+      child: errors.isEmpty
+          ? Row(
+              children: [
+                Icon(
+                  Icons.check_circle_outline_rounded,
+                  size: 16,
+                  color: colorScheme.secondary,
+                ),
+                const SizedBox(width: UssdDesignSystem.spacingS),
+                Text(
+                  'No errors recorded.',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: colorScheme.secondary,
+                  ),
+                ),
+              ],
+            )
+          : Column(
+              children: errors.map((e) {
+                final msg = e.metadata['error'] as String? ?? 'Unknown error';
+                return ListTile(
+                  contentPadding: EdgeInsets.zero,
+                  dense: true,
+                  leading: Icon(
+                    Icons.error_outline_rounded,
+                    size: 16,
+                    color: colorScheme.error,
+                  ),
+                  title: Text(
+                    msg,
+                    style: Theme.of(context).textTheme.bodySmall,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  subtitle: Text(
+                    '${e.serviceCode} · ${_formatTime(e.timestamp)}',
+                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                );
+              }).toList(),
+            ),
+    );
+  }
+
+  String _formatTime(DateTime dt) =>
+      '${dt.hour.toString().padLeft(2, '0')}:${dt.minute.toString().padLeft(2, '0')} '
+      '${dt.day}/${dt.month}';
+}
+
+// ── Actions card (export + clear) ────────────────────────────────────────────
+
+class _ActionsCard extends StatelessWidget {
+  final AnalyticsService analytics;
+  const _ActionsCard({required this.analytics});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return _DashCard(
+      icon: Icons.settings_rounded,
+      title: 'Data & Settings',
+      child: Column(
+        children: [
+          // Analytics toggle
+          SwitchListTile(
+            contentPadding: EdgeInsets.zero,
+            dense: true,
+            title: Text(
+              'Enable analytics',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            subtitle: Text(
+              'Track session events and response times',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ),
+            value: analytics.enabled,
+            onChanged: analytics.setEnabled,
+          ),
+          const Divider(height: UssdDesignSystem.spacingL),
+          // Export buttons
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton.icon(
+                  onPressed: analytics.metrics.isEmpty
+                      ? null
+                      : () => _export(context, 'csv'),
+                  icon: const Icon(Icons.table_chart_rounded, size: 18),
+                  label: const Text('CSV'),
+                ),
+              ),
+              const SizedBox(width: UssdDesignSystem.spacingS),
+              Expanded(
+                child: OutlinedButton.icon(
+                  onPressed: analytics.events.isEmpty && analytics.metrics.isEmpty
+                      ? null
+                      : () => _export(context, 'json'),
+                  icon: const Icon(Icons.data_object_rounded, size: 18),
+                  label: const Text('JSON'),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: UssdDesignSystem.spacingS),
+          FilledButton.icon(
+            onPressed: analytics.events.isEmpty && analytics.metrics.isEmpty
+                ? null
+                : () => _confirmClear(context),
+            icon: const Icon(Icons.delete_sweep_rounded, size: 18),
+            label: const Text('Clear all analytics data'),
+            style: FilledButton.styleFrom(
+              backgroundColor: colorScheme.error,
+              foregroundColor: colorScheme.onError,
+              minimumSize: const Size(double.infinity, 44),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _export(BuildContext context, String format) async {
+    try {
+      final content = format == 'csv'
+          ? analytics.exportCsv()
+          : analytics.exportJson();
+      final ext = format == 'csv' ? 'csv' : 'json';
+      final dir = await getTemporaryDirectory();
+      final file = File(
+        '${dir.path}/ussd_analytics_${DateTime.now().millisecondsSinceEpoch}.$ext',
+      );
+      await file.writeAsString(content);
+      await Share.shareXFiles(
+        [XFile(file.path)],
+        subject: 'USSD Analytics Export',
+      );
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Export failed: $e'),
+            backgroundColor: Theme.of(context).colorScheme.error,
+          ),
+        );
+      }
+    }
+  }
+
+  void _confirmClear(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(UssdDesignSystem.radiusL),
+        ),
+        title: const Text('Clear analytics data'),
+        content: const Text(
+          'This will permanently delete all recorded events and metrics.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(ctx).colorScheme.error,
+              foregroundColor: Theme.of(ctx).colorScheme.onError,
+            ),
+            onPressed: () {
+              analytics.clearAll();
+              Navigator.of(ctx).pop();
+            },
+            child: const Text('Clear'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── Shared card shell ────────────────────────────────────────────────────────
+
+class _DashCard extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final Widget child;
+
+  const _DashCard({
+    required this.icon,
+    required this.title,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Card(
+      elevation: 1,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(UssdDesignSystem.radiusL),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(UssdDesignSystem.spacingL),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(icon, size: 18, color: colorScheme.primary),
+                const SizedBox(width: UssdDesignSystem.spacingS),
+                Text(
+                  title,
+                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: UssdDesignSystem.spacingM),
+            child,
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MetricPill extends StatelessWidget {
+  final String label;
+  final String value;
+  final Color color;
+
+  const _MetricPill({
+    required this.label,
+    required this.value,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: UssdDesignSystem.spacingM,
+        vertical: UssdDesignSystem.spacingXS,
+      ),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.12),
+        borderRadius: BorderRadius.circular(UssdDesignSystem.radiusM),
+      ),
+      child: Column(
+        children: [
+          Text(
+            value,
+            style: Theme.of(context).textTheme.labelLarge?.copyWith(
+              color: color,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          Text(
+            label,
+            style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: color.withOpacity(0.8),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -14,6 +14,7 @@ import 'endpoint_config_screen.dart';
 import 'session_history_screen.dart';
 import 'template_library_screen.dart';
 import 'accessibility_settings_screen.dart';
+import 'analytics_dashboard_screen.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -166,6 +167,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
       const EndpointConfigScreen(),
       const SessionHistoryScreen(),
       const TemplateLibraryScreen(),
+      const AnalyticsDashboardScreen(),
     ];
 
     return Scaffold(
@@ -297,6 +299,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                 l10n.configuration,
                 l10n.sessionHistory,
                 l10n.templates,
+                'Analytics',
               ][index];
               accessibilityProvider.announceForScreenReader(
                 l10n.navigatedToScreen(screenName),
@@ -327,6 +330,11 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
                 icon: _buildNavIcon(Icons.folder_special_rounded, 3),
                 label: l10n.templates,
                 tooltip: l10n.templateLibraryTooltip,
+              ),
+              BottomNavigationBarItem(
+                icon: _buildNavIcon(Icons.bar_chart_rounded, 4),
+                label: 'Analytics',
+                tooltip: 'Session analytics and performance',
               ),
             ],
           ),

--- a/lib/services/analytics_service.dart
+++ b/lib/services/analytics_service.dart
@@ -1,0 +1,319 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:uuid/uuid.dart';
+import '../models/analytics_models.dart';
+
+/// Records session events and response metrics locally.
+/// All data is stored in shared_preferences — no PII is collected.
+/// Phone numbers and session IDs are the only identifiers; they are
+/// stored only on-device and never transmitted.
+class AnalyticsService extends ChangeNotifier {
+  static const String _eventsKey = 'analytics_events';
+  static const String _metricsKey = 'analytics_metrics';
+  static const int _maxEvents = 500;
+  static const int _maxMetrics = 500;
+
+  static const _uuid = Uuid();
+
+  SharedPreferences? _prefs;
+  final List<SessionEvent> _events = [];
+  final List<ResponseMetric> _metrics = [];
+
+  // In-flight timers: requestId → start time
+  final Map<String, DateTime> _timers = {};
+
+  bool _enabled = true;
+  bool get enabled => _enabled;
+
+  List<SessionEvent> get events => List.unmodifiable(_events);
+  List<ResponseMetric> get metrics => List.unmodifiable(_metrics);
+
+  Future<void> init() async {
+    _prefs = await SharedPreferences.getInstance();
+    _loadEvents();
+    _loadMetrics();
+  }
+
+  // ── Persistence ──────────────────────────────────────────────────────────
+
+  void _loadEvents() {
+    final raw = _prefs?.getString(_eventsKey);
+    if (raw == null) return;
+    try {
+      final list = jsonDecode(raw) as List<dynamic>;
+      _events.clear();
+      for (final item in list) {
+        try {
+          _events.add(SessionEvent.fromJson(item as Map<String, dynamic>));
+        } catch (_) {}
+      }
+    } catch (e) {
+      debugPrint('AnalyticsService: failed to load events: $e');
+    }
+  }
+
+  void _loadMetrics() {
+    final raw = _prefs?.getString(_metricsKey);
+    if (raw == null) return;
+    try {
+      final list = jsonDecode(raw) as List<dynamic>;
+      _metrics.clear();
+      for (final item in list) {
+        try {
+          _metrics.add(ResponseMetric.fromJson(item as Map<String, dynamic>));
+        } catch (_) {}
+      }
+    } catch (e) {
+      debugPrint('AnalyticsService: failed to load metrics: $e');
+    }
+  }
+
+  Future<void> _saveEvents() async {
+    try {
+      await _prefs?.setString(
+        _eventsKey,
+        jsonEncode(_events.map((e) => e.toJson()).toList()),
+      );
+    } catch (e) {
+      debugPrint('AnalyticsService: failed to save events: $e');
+    }
+  }
+
+  Future<void> _saveMetrics() async {
+    try {
+      await _prefs?.setString(
+        _metricsKey,
+        jsonEncode(_metrics.map((m) => m.toJson()).toList()),
+      );
+    } catch (e) {
+      debugPrint('AnalyticsService: failed to save metrics: $e');
+    }
+  }
+
+  // ── Event tracking ────────────────────────────────────────────────────────
+
+  Future<void> trackSessionStart({
+    required String sessionId,
+    required String serviceCode,
+    required String endpointName,
+  }) async {
+    if (!_enabled) return;
+    await _addEvent(SessionEvent(
+      id: _uuid.v4(),
+      type: SessionEventType.sessionStart,
+      timestamp: DateTime.now(),
+      sessionId: sessionId,
+      serviceCode: serviceCode,
+      endpointName: endpointName,
+    ));
+  }
+
+  Future<void> trackSessionEnd({
+    required String sessionId,
+    required String serviceCode,
+    required String endpointName,
+    required int messageCount,
+  }) async {
+    if (!_enabled) return;
+    await _addEvent(SessionEvent(
+      id: _uuid.v4(),
+      type: SessionEventType.sessionEnd,
+      timestamp: DateTime.now(),
+      sessionId: sessionId,
+      serviceCode: serviceCode,
+      endpointName: endpointName,
+      metadata: {'messageCount': messageCount},
+    ));
+  }
+
+  Future<void> trackError({
+    required String sessionId,
+    required String serviceCode,
+    required String endpointName,
+    required String error,
+  }) async {
+    if (!_enabled) return;
+    await _addEvent(SessionEvent(
+      id: _uuid.v4(),
+      type: SessionEventType.error,
+      timestamp: DateTime.now(),
+      sessionId: sessionId,
+      serviceCode: serviceCode,
+      endpointName: endpointName,
+      metadata: {'error': error},
+    ));
+  }
+
+  Future<void> _addEvent(SessionEvent event) async {
+    _events.add(event);
+    if (_events.length > _maxEvents) {
+      _events.removeRange(0, _events.length - _maxEvents);
+    }
+    await _saveEvents();
+    notifyListeners();
+  }
+
+  // ── Response time tracking ────────────────────────────────────────────────
+
+  /// Call before sending a request; returns a timer ID to pass to [endTimer].
+  String startTimer() {
+    final id = _uuid.v4();
+    _timers[id] = DateTime.now();
+    return id;
+  }
+
+  /// Call after receiving a response. Records the metric and returns elapsed ms.
+  Future<int> endTimer({
+    required String timerId,
+    required String sessionId,
+    required String endpointName,
+    required String serviceCode,
+    required bool success,
+    String? errorMessage,
+  }) async {
+    final start = _timers.remove(timerId);
+    final elapsed = start != null
+        ? DateTime.now().difference(start).inMilliseconds
+        : 0;
+
+    if (!_enabled) return elapsed;
+
+    final metric = ResponseMetric(
+      id: _uuid.v4(),
+      sessionId: sessionId,
+      endpointName: endpointName,
+      serviceCode: serviceCode,
+      responseTimeMs: elapsed,
+      success: success,
+      errorMessage: errorMessage,
+      timestamp: DateTime.now(),
+    );
+
+    _metrics.add(metric);
+    if (_metrics.length > _maxMetrics) {
+      _metrics.removeRange(0, _metrics.length - _maxMetrics);
+    }
+    await _saveMetrics();
+    notifyListeners();
+    return elapsed;
+  }
+
+  // ── Summary computation ───────────────────────────────────────────────────
+
+  AnalyticsSummary computeSummary() {
+    if (_events.isEmpty && _metrics.isEmpty) return AnalyticsSummary.empty();
+
+    final starts = _events
+        .where((e) => e.type == SessionEventType.sessionStart)
+        .toList();
+    final ends = _events
+        .where((e) => e.type == SessionEventType.sessionEnd)
+        .toList();
+    final errors = _events
+        .where((e) => e.type == SessionEventType.error)
+        .toList();
+
+    // Sessions by service code
+    final byCode = <String, int>{};
+    for (final e in starts) {
+      byCode[e.serviceCode] = (byCode[e.serviceCode] ?? 0) + 1;
+    }
+
+    // Avg response time by endpoint
+    final timesByEndpoint = <String, List<int>>{};
+    for (final m in _metrics) {
+      timesByEndpoint.putIfAbsent(m.endpointName, () => []).add(m.responseTimeMs);
+    }
+    final avgByEndpoint = timesByEndpoint.map(
+      (k, v) => MapEntry(k, v.reduce((a, b) => a + b) / v.length),
+    );
+
+    // Errors by endpoint
+    final errorsByEndpoint = <String, int>{};
+    for (final e in errors) {
+      errorsByEndpoint[e.endpointName] =
+          (errorsByEndpoint[e.endpointName] ?? 0) + 1;
+    }
+
+    // Overall avg response time
+    final allTimes = _metrics.map((m) => m.responseTimeMs).toList();
+    final avgMs = allTimes.isEmpty
+        ? 0.0
+        : allTimes.reduce((a, b) => a + b) / allTimes.length;
+
+    // Total session duration (sum of start→end pairs per sessionId)
+    var totalDuration = Duration.zero;
+    for (final start in starts) {
+      final end = ends
+          .where((e) => e.sessionId == start.sessionId)
+          .toList();
+      if (end.isNotEmpty) {
+        totalDuration +=
+            end.first.timestamp.difference(start.timestamp).abs();
+      }
+    }
+
+    final totalRequests = _metrics.length;
+    final totalErrors = errors.length;
+
+    return AnalyticsSummary(
+      totalSessions: starts.length,
+      totalRequests: totalRequests,
+      totalErrors: totalErrors,
+      avgResponseTimeMs: avgMs,
+      errorRate: totalRequests == 0
+          ? 0
+          : (_metrics.where((m) => !m.success).length / totalRequests) * 100,
+      sessionsByServiceCode: byCode,
+      avgResponseTimeByEndpoint: avgByEndpoint,
+      errorsByEndpoint: errorsByEndpoint,
+      totalSessionDuration: totalDuration,
+    );
+  }
+
+  // ── Settings & data management ────────────────────────────────────────────
+
+  void setEnabled(bool value) {
+    _enabled = value;
+    notifyListeners();
+  }
+
+  Future<void> clearAll() async {
+    _events.clear();
+    _metrics.clear();
+    _timers.clear();
+    await _prefs?.remove(_eventsKey);
+    await _prefs?.remove(_metricsKey);
+    notifyListeners();
+  }
+
+  /// Export all data as a JSON string.
+  String exportJson() {
+    return jsonEncode({
+      'exportedAt': DateTime.now().toIso8601String(),
+      'events': _events.map((e) => e.toJson()).toList(),
+      'metrics': _metrics.map((m) => m.toJson()).toList(),
+    });
+  }
+
+  /// Export metrics as CSV rows (header + data).
+  String exportCsv() {
+    final buf = StringBuffer();
+    buf.writeln(
+      'timestamp,sessionId,endpointName,serviceCode,responseTimeMs,success,errorMessage',
+    );
+    for (final m in _metrics) {
+      buf.writeln(
+        '${m.timestamp.toIso8601String()},'
+        '${m.sessionId},'
+        '${m.endpointName},'
+        '${m.serviceCode},'
+        '${m.responseTimeMs},'
+        '${m.success},'
+        '${m.errorMessage ?? ''}',
+      );
+    }
+    return buf.toString();
+  }
+}


### PR DESCRIPTION
Closes #7

## What this adds

### Data models (`lib/models/analytics_models.dart`)

- **`SessionEvent`** — typed event record (`sessionStart`, `sessionEnd`, `requestSent`, `responseReceived`, `error`) with a metadata map for arbitrary context
- **`ResponseMetric`** — per-request timing record: endpoint name, service code, elapsed ms, success flag, optional error message
- **`AnalyticsSummary`** — computed aggregate derived on demand from raw data: total sessions/requests/errors, avg response time, error rate, per-endpoint breakdown, per-service-code session counts, total session duration

No code generation — plain JSON serialization via `toJson`/`fromJson`.

### Service (`lib/services/analytics_service.dart`)

- Persists events and metrics in `shared_preferences` (max 500 each, FIFO eviction — no new dependencies)
- `startTimer()` / `endTimer()` pair for response time measurement around API calls
- `trackSessionStart`, `trackSessionEnd`, `trackError` for lifecycle events
- `computeSummary()` derives `AnalyticsSummary` from raw stored data
- `exportCsv()` and `exportJson()` for data export
- `setEnabled(bool)` toggle; `clearAll()` for data management

### Provider integration (`lib/providers/ussd_provider.dart`)

`AnalyticsService` is injected as an **optional** constructor parameter — existing tests that call `UssdProvider()` with no args are unaffected.

| Hook | What is tracked |
|---|---|
| `startSession` | `trackSessionStart` after session is created |
| `endSession` | `trackSessionEnd` before session is cleared |
| `_sendWithOfflineFallback` (online path) | `startTimer`/`endTimer` wrapping every live API call |
| Network failure | `trackError` + `endTimer(success: false)` |

### Dashboard (`lib/screens/analytics_dashboard_screen.dart`)

- **Summary row** — total sessions, requests, errors, avg response time (4 stat cards)
- **Response time chart** — bar chart of last 20 requests, colour-coded green/red by success
- **Top service codes** — top 5 by session count with proportional progress bars
- **Endpoint performance** — avg response time per endpoint, error badge for endpoints with failures; endpoints >2 s highlighted in error colour
- **Recent errors** — last 5 error events with message and timestamp
- **Settings card** — analytics on/off toggle, CSV export, JSON export (via `share_plus`), clear-all with confirmation dialog

All sections animate in with staggered fade+slide using `flutter_animate`.

### Navigation (`lib/screens/home_screen.dart`)

Analytics added as the 5th tab in `BottomNavigationBar` with `Icons.bar_chart_rounded`.

## Design decisions

- **No new dependencies** — `share_plus`, `path_provider`, and `uuid` are already in `pubspec.yaml`
- **On-device only** — no data leaves the device; phone numbers and session IDs are stored locally and never transmitted
- **Computed summaries** — `AnalyticsSummary` is derived on each `computeSummary()` call rather than stored, keeping the persistence layer simple and avoiding stale aggregates

## Files changed

| File | Change |
|---|---|
| `lib/models/analytics_models.dart` | New — `SessionEvent`, `ResponseMetric`, `AnalyticsSummary` |
| `lib/services/analytics_service.dart` | New — event/metric recording, persistence, export |
| `lib/screens/analytics_dashboard_screen.dart` | New — full dashboard UI |
| `lib/providers/ussd_provider.dart` | Inject `AnalyticsService`; instrument session lifecycle and API calls |
| `lib/main.dart` | Register `AnalyticsService`; upgrade proxy provider to `ProxyProvider4` |
| `lib/screens/home_screen.dart` | Add Analytics tab to nav bar |